### PR TITLE
added offsetCount option to CustomListView Widget

### DIFF
--- a/lib/src/custom_list_view.dart
+++ b/lib/src/custom_list_view.dart
@@ -11,6 +11,7 @@ class CustomListView<T> extends StatefulWidget {
   const CustomListView({
     Key key,
     this.pageSize = 30,
+    this.offsetCount = 1,
     this.header,
     this.footer,
     this.empty = const SizedBox(),
@@ -39,6 +40,9 @@ class CustomListView<T> extends StatefulWidget {
 
   /// Item count to request on each time list is scrolled to the end
   final int pageSize;
+
+  /// Offset count to start first page from
+  final int offsetCount;
 
   /// Widget to be be displayed on the top of other items
   final Widget header;
@@ -171,7 +175,7 @@ class CustomListViewState extends State<CustomListView> {
   }
 
   /// Clears [items] and loads data from adapter.
-  Future reload() => fetchFromAdapter(offset: 0, merge: false);
+  Future reload() => fetchFromAdapter(offset: widget.offsetCount, merge: false);
 
   Future refresh() async {
     if (widget.onRefresh != null) {

--- a/lib/src/custom_list_view.dart
+++ b/lib/src/custom_list_view.dart
@@ -11,7 +11,7 @@ class CustomListView<T> extends StatefulWidget {
   const CustomListView({
     Key key,
     this.pageSize = 30,
-    this.offsetCount = 1,
+    this.initialOffset = 0,
     this.header,
     this.footer,
     this.empty = const SizedBox(),
@@ -41,8 +41,8 @@ class CustomListView<T> extends StatefulWidget {
   /// Item count to request on each time list is scrolled to the end
   final int pageSize;
 
-  /// Offset count to start first page from
-  final int offsetCount;
+  /// Initial offset value
+  final int initialOffset;
 
   /// Widget to be be displayed on the top of other items
   final Widget header;
@@ -175,7 +175,7 @@ class CustomListViewState extends State<CustomListView> {
   }
 
   /// Clears [items] and loads data from adapter.
-  Future reload() => fetchFromAdapter(offset: widget.offsetCount, merge: false);
+  Future reload() => fetchFromAdapter(offset: widget.initialOffset, merge: false);
 
   Future refresh() async {
     if (widget.onRefresh != null) {


### PR DESCRIPTION
**Context:** When pulling data from WordPress API (V2) endpoint, the `page`  query parameter doesn't accept zero.
`offsetParam` in `NetworkListAdapter` only accepts the parameter name and it doesn't cover the initial value.

**Solution:** I added an `offsetCount` option to the widget so if I want to start from page number eg 1, 2, 3 ... I just added `offsetCount` parameter.

Example:
```
CustomListView( 
  // What page to start from (default: 1)
  offsetCount: 1,
),
```