### PR TITLE
Add pagination mode

### DIFF
--- a/lib/src/custom_list_view.dart
+++ b/lib/src/custom_list_view.dart
@@ -10,7 +10,7 @@ import 'types.dart';
 class CustomListView<T> extends StatefulWidget {
   const CustomListView({
     Key key,
-    this.paginationMode = 0,
+    this.paginationMode = CustomListView.OFFSET_MODE,
     this.pageSize = 30,
     this.initialOffset = 0,
     this.header,

--- a/lib/src/custom_list_view.dart
+++ b/lib/src/custom_list_view.dart
@@ -10,6 +10,7 @@ import 'types.dart';
 class CustomListView<T> extends StatefulWidget {
   const CustomListView({
     Key key,
+    this.paginationMode = 0,
     this.pageSize = 30,
     this.initialOffset = 0,
     this.header,
@@ -35,8 +36,16 @@ class CustomListView<T> extends StatefulWidget {
         assert(adapter != null || itemCount != null),
         assert(debounceDuration != null),
         assert(distanceToLoadMore != null),
+        assert(paginationMode == CustomListView.OFFSET_MODE ||
+            paginationMode == CustomListView.PAGE_MODE),
         this.itemExtend = separatorBuilder == null ? itemExtend : null,
         super(key: key);
+
+  static const OFFSET_MODE = 0;
+  static const PAGE_MODE = 1;
+
+  /// pagination mode (offset / page)
+  final int paginationMode;
 
   /// Item count to request on each time list is scrolled to the end
   final int pageSize;
@@ -127,6 +136,7 @@ class CustomListViewState extends State<CustomListView> {
   final ValueNotifier<_CLVState> _stateNotifier =
       ValueNotifier(_CLVState.loading);
   final List items = [];
+  int _pageNumber = 0;
 
   bool _reachedToEnd = false;
   bool _loading = false;
@@ -136,11 +146,13 @@ class CustomListViewState extends State<CustomListView> {
   bool get loading => _loading;
   bool get fetching => _fetching;
   bool get reachedToEnd => _reachedToEnd;
+  int get pageNumber => _pageNumber;
 
   @override
   void initState() {
     super.initState();
 
+    _pageNumber = widget.initialOffset;
     if (!loadMore()) {
       _stateNotifier.value = _CLVState.idle;
     }
@@ -157,7 +169,14 @@ class CustomListViewState extends State<CustomListView> {
     _fetching = true;
 
     try {
-      int skip = offset ?? items?.length ?? 0;
+      int skip;
+      if (widget.paginationMode == CustomListView.OFFSET_MODE)
+        skip = offset ?? items?.length ?? 0;
+      else if (widget.paginationMode == CustomListView.PAGE_MODE) {
+        skip = offset ?? _pageNumber;
+        _pageNumber++;
+      } else
+        skip = 0;
       ListItems result = await widget.adapter.getItems(skip, widget.pageSize);
 
       if (mounted) {
@@ -175,7 +194,8 @@ class CustomListViewState extends State<CustomListView> {
   }
 
   /// Clears [items] and loads data from adapter.
-  Future reload() => fetchFromAdapter(offset: widget.initialOffset, merge: false);
+  Future reload() =>
+      fetchFromAdapter(offset: widget.initialOffset, merge: false);
 
   Future refresh() async {
     if (widget.onRefresh != null) {


### PR DESCRIPTION
This pull request is revision for a previous pull request #7 since WordPress API uses page number for pagination (not offset)

**Problem:** When pulling data from WordPress API (V2) endpoint, the `page` query parameter is hopping like 1, 30, 60 ... which is of course not expected (should be 1, 2, 3 ...)

**Solution:** I added the `paginationMode` parameter to switch between two modes (**offset mode** and **page mode**) (leaving the original mode as default) which will help developers choose what fits best for their API.

**Example:**
```
CustomListView( 
  // CustomListView.OFFSET_MODE / CustomListView.PAGE_MODE
  // OFFSET_MODE uses the same old functionality (offset = items.length)
  // PAGE_MODE increments offset (now called page) one by one when loading (offset = pageNum + 1)
  paginationMode: CustomListView.OFFSET_MODE,
),
```