### PR TITLE
Pass the physics parameter to the CustomScrollView

### DIFF
--- a/lib/src/custom_list_view.dart
+++ b/lib/src/custom_list_view.dart
@@ -350,6 +350,7 @@ class CustomListViewState extends State<CustomListView> {
       shrinkWrap: widget.shrinkWrap,
       semanticChildCount: itemCount,
       controller: widget.controller,
+      physics: widget.physics,
       slivers: slivers.map((sliver) {
         int index = i++;
         return SliverPadding(


### PR DESCRIPTION
Hello,

The physics parameter is never passed from the Widget to the CustomScrollView.
This PR fixes this.