### PR TITLE
add "dataPath" option to network list adapter to specify data array's path

### DIFF
--- a/lib/src/adapters/network_list_adapter.dart
+++ b/lib/src/adapters/network_list_adapter.dart
@@ -12,6 +12,7 @@ class NetworkListAdapter<T> implements BaseListAdapter<T> {
   final String offsetParam;
   final bool disablePagination;
   final Map<String, String> headers;
+  final String dataPath;
 
   const NetworkListAdapter({
     @required this.url,
@@ -20,6 +21,7 @@ class NetworkListAdapter<T> implements BaseListAdapter<T> {
     this.disablePagination = false,
     this.client,
     this.headers,
+    this.dataPath,
   })  : assert(url != null),
         assert(disablePagination == true || limitParam != null),
         assert(disablePagination == true || offsetParam != null);
@@ -48,7 +50,9 @@ class NetworkListAdapter<T> implements BaseListAdapter<T> {
     });
 
     if (response.statusCode < 300) {
-      Iterable items = json.decode(utf8.decode(response.bodyBytes));
+      Iterable items = dataPath == null
+          ? json.decode(utf8.decode(response.bodyBytes))
+          : json.decode(utf8.decode(response.bodyBytes))[dataPath];
       return ListItems(
         items,
         reachedToEnd: disablePagination == true || items.length == 0,


### PR DESCRIPTION
**Problem**: One of my friends was trying to use this package to get data from a Laravel API and his problem was that if he wants to get paginated items then the structure of response:
```
{
  "data": [], // array of items to iterate through (our target)
  "links": {},
  "meta": {}
}
```
with this response, the network list adapter won't find.

**Solution**: Added new option to specify the path of the data.

**Example**:
```
NetworkListAdapter(
  dataPath: 'data',
)
```