### PR TITLE
Fixes #11

### DIFF
--- a/lib/src/custom_list_view.dart
+++ b/lib/src/custom_list_view.dart
@@ -289,7 +289,7 @@ class CustomListViewState extends State<CustomListView> {
     return SliverChildBuilderDelegate(
       (context, int index) {
         if (widget.separatorBuilder != null) {
-          if (index.isEven) {
+          if (index.isOdd) {
             return widget.separatorBuilder(context, index ~/ 2);
           } else {
             index = index ~/ 2;


### PR DESCRIPTION
Let's say we have 3 elements with Separators. itemCount = 3, realItemCount = 5 because we need two separators to separate 3 elements. In this case the displayed elements should be: [E0, sep, E1, sep, E3]. The original code generated this: [sep, E0, sep, E1, sep]. Because it placed the separators to the even indexes (0, 2, 4). It should be the other way around and separators should be at the odd indexes (1 & 3), while 0, 2, 4 real indexes will have the elements. Now if someone has header or footer and if those are separated, that's another question.

This is a one liner fix, I haven't used several features of the list utils, so please revise if this fix could interfere with any orthogonal features, like for example header or footer separation I can think of.