### PR TITLE
Fix #13

### DIFF
--- a/lib/src/adapters/static_list_adapter.dart
+++ b/lib/src/adapters/static_list_adapter.dart
@@ -16,7 +16,7 @@ class StaticListAdapter<T> implements BaseListAdapter<T> {
       return Future.value(ListItems(data, reachedToEnd: data.length == 0));
     } else {
       var items = data.skip(offset).take(limit).toList();
-      return Future.value(ListItems(items, reachedToEnd: items.length == 0));
+      return Future.value(ListItems(items, reachedToEnd: items.length < limit));
     }
   }
 


### PR DESCRIPTION
This signal to the core that there are no more pages in case of `disablePagination` is `true` (default). Maybe the `disablePagination` `false` branch's clause could be corrected as well, but here I don't modify it. With this change if I set the pagination mode to offset, then I can have a scenario when no more copies of the fixed list will be duplicated on the UI.

Fixes #13 