### PR TITLE
Check if adapter is present before serving items list

### DIFF
--- a/lib/src/custom_list_view.dart
+++ b/lib/src/custom_list_view.dart
@@ -296,7 +296,11 @@ class CustomListViewState extends State<CustomListView> {
           }
         }
 
-        return widget.itemBuilder(context, index, items[index]);
+        return widget.itemBuilder(
+          context,
+          index,
+          widget.adapter != null ? items[index] : null,
+        );
       },
       semanticIndexCallback: (_, int index) {
         if (widget.separatorBuilder != null) {


### PR DESCRIPTION
#18 Fix for the RangeError when using v0.2.x versions of the package

When there is no adapter in use the items list will have no entries and thus the access of index 0 will result in a rangeError. Checking if an adapter is present before accessing the list will prevent this behavior.